### PR TITLE
Fix make clean to work with jobserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ clean :
 	-rm -rf *.o *.d c_so_dep.txt lua_so_dep.txt ar_dep.txt $(TEST) \
         $(C_SO_NAME) $(LUA_SO_NAME) $(TEST) $(BUILD_SO_DIR) $(BUILD_AR_DIR) \
         $(AR_NAME)
-	make clean -C tests
+	$(MAKE) clean -C tests
 
 install:
 	install -D -m 755 $(C_SO_NAME) $(DESTDIR)/$(SO_TARGET_DIR)/$(C_SO_NAME)


### PR DESCRIPTION
Previously calling aho-corasick Makefile from parent make printed following error:
```
make[2]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
```